### PR TITLE
Reindex using ES bulk API

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "nxus-tester-jest": "^4.0.9",
     "pluralize": "^1.2.1",
     "underscore": "^1.8.3",
-    "waterline-elasticsearch": "git+https://github.com/seabourne/waterline-elasticsearch.git#4.0"
+    "waterline-elasticsearch": "git+https://github.com/seabourne/waterline-elasticsearch.git#fix/add-native"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "nxus-router": "^4.0.0",
     "nxus-storage": "^4.0.0",
     "nxus-templater": "^4.0.0",
-    "nxus-tester-jest": "^4.0.9",
     "pluralize": "^1.2.1",
     "underscore": "^1.8.3",
     "waterline-elasticsearch": "git+https://github.com/seabourne/waterline-elasticsearch.git#fix/add-native"
@@ -37,11 +36,8 @@
     "babel-core": "^6.9.0",
     "babel-plugin-transform-object-rest-spread": "^6.8.0",
     "babel-preset-env": "^1.6.1",
-    "chai": "^3.5.0",
-    "chai-as-promised": "^5.2.0",
     "documentation": "^4.0.0-beta",
-    "mocha": "^2.2.5",
-    "should": "^7.0.2",
+    "nxus-tester-jest": "^4.0.9",
     "sinon": "^1.17.7"
   },
   "directories": {

--- a/test/integration.js
+++ b/test/integration.js
@@ -14,6 +14,13 @@ function processor(doc) {
 }
 processor = sinon.spy(processor)
 
+function reprocessor(doc) {
+  doc.upper_name = doc.name.toUpperCase()
+  return doc
+  
+}
+reprocessor = sinon.spy(reprocessor)
+
 describe('Integration', () => {
   describe("searchable", () => {
     it("registers model", async () => {
@@ -98,6 +105,21 @@ describe('Integration', () => {
       expect(res.total).toEqual(0)
     })
     
+  })
+
+  describe("reindex", () => {
+    it("reindexes and refreshes all model processing", async () => {
+      await searcher.searchable('test-model2', {processor: reprocessor})
+      await searcher.reindex('test-model2')
+      await timeout(200)
+      await tester.searcherRefresh()
+      
+      let res = await searcher.search('test-model2', 'Model')
+      expect(res.total).toEqual(1)
+      expect(res[0].upper_name).toEqual('TEST MODEL')
+      expect(reprocessor.callCount).toEqual(1)
+        
+    })    
   })
 
   describe("errors", () => {


### PR DESCRIPTION
Change `searcher.reindex` behavior to use the ES Bulk API, still chunked but in bulk requests of 1000 index calls now rather than 100 concurrent index requests.

Resolves #17 