### PR TITLE
Fix to reduce reindex memory requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,6 @@ Reindex all of a model's documents. Different services concurrent request and qu
 **Parameters**
 
 -   `model` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the model identity
--   `concurrent` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** how many docs to concurrently process (optional, default `100`)
+-   `concurrent` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** how many docs to concurrently process (optional, default `1000`)
 -   `interval` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** ms to wait between doc chunks (optional, default `100`)
 -   `start` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** to restart indexing from midway (optional, default `0`)

--- a/README.md
+++ b/README.md
@@ -310,4 +310,3 @@ Reindex all of a model's documents. Different services concurrent request and qu
 -   `model` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the model identity
 -   `concurrent` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** how many docs to concurrently process (optional, default `1000`)
 -   `interval` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** ms to wait between doc chunks (optional, default `100`)
--   `start` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** to restart indexing from midway (optional, default `0`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nxus-searcher",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A search framework for Nxus apps",
   "main": "lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "homepage": "",
   "dependencies": {
     "@lifeomic/attempt": "^3.0.0",
-    "bluebird": "^3.3.1",
     "nxus-core": "^4.1.0",
     "nxus-router": "^4.0.0",
     "nxus-storage": "^4.0.0",


### PR DESCRIPTION
The `reindex()` method loaded the entire collection being reindexed, which caused an out-of-memory condition on large collections. Refactored it to load the collection in chunks. (It was already doing an ElasticSearch bulk update in chunks, so just loaded the records required for each update chunk.)

Removed the optional `start` parameter from `reindex()`. Belief is that it was added for use in development, and was never used in production code.

Also did some cosmetic cleanup: Fixed some things ESLint was complaining about. Used standard Promise instead of Bluebird.